### PR TITLE
Carrier invoices API docs

### DIFF
--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -819,6 +819,20 @@ Response:
           }
         }
       ],
+      "shipped_items": [{
+        "external_id": "1234",
+        "description": "Shipped item",
+        "weight_unit": "lb",
+        "quantity": 2.0,
+        "item_type": "CARTON",
+        "hazardous_material": false,
+        "weight": 417.0,
+        "class_name": '400',
+        "nmfc": "82270",
+        "width": 10.0,
+        "height": 12.0,
+        "length": 20.0
+      }],
       "documents": [
         {
           "id": 14,

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -132,9 +132,11 @@ Request:
     ],
     "line_items": [ // Displayed and used to calculate the carrier_charge.
       {
+        "external_id": "line_item_1", // You're id for matching up line items when sending back to your TMS
         "description": "line item description",
         "total": 123.45,
         "quantity": 5,
+        "rate": 2.0,
         "type_code": "abc",
         "customer_total": 150.00,
         "carrier": { // Used to calculate carrier_charge for each carrier
@@ -293,9 +295,11 @@ Response:
     ],
     "line_items": [ // Displayed and used to calculate the carrier_charge. Empty array if no line items.
       {
+        "external_id": "line_item_1", // You're id for matching up line items when sending back to your TMS
         "description": "line item description",
         "total": 123.45,
         "quantity": 5,
+        "rate": 2.0,
         "type_code": "abc",
         "customer_total": 150.00,
         "carrier": { // Used to calculate carrier_charge for each carrier
@@ -446,9 +450,11 @@ Request:
       },
       "line_items": [
         {
+          "external_id": "line_item_1", // The line external_id you sent us
           "description": "line item description",
           "total": 123.45,
           "quantity": 5,
+          "rate": 2.0,
           "type_code": "abc"
         }
       ],
@@ -846,9 +852,11 @@ Response:
       },
       "line_items": [
         {
+          "external_id": "line_item_1", // The line external_id you sent us
           "description": "line item description",
           "total": 123.45,
           "quantity": 3,
+          "rate": 2.0,
           "type_code": "abc",
           "customer_total": 150.00,
           "carrier": {

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -730,7 +730,11 @@ Response:
 
 On success:
 ```
-{}
+{
+  "document": {
+    "id": 5, // HubTran's internal id for the document
+  }
+}
 ```
 
 On Failure:

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -806,6 +806,15 @@ Response:
       load: {
         "external_id": "load-external-id"
       },
+      "line_items": [
+        {
+          "description": "line item description",
+          "total": 123.45,
+          "carrier": {
+            "external_id": "carrier-external-id",
+          }
+        }
+      ],
       "documents": [
         {
           "id": 14,

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -40,6 +40,7 @@ Request:
     "load_id": "load-id", // Required
     "external_id": "external-id", // Required
     "status": "new",
+    "brokered": true,
     "tms_created_at": "2016-07-15 19:00:00 +0200",
     "tms_updated_at": "2016-07-17 19:00:00 +0200",
     "target_ship_start": "2016-07-16 12:00:00 +0200",
@@ -68,7 +69,6 @@ Request:
     "ppe": "ppe",
     "quote_number": "quote-number",
     "ship_ref": "ship-ref",
-    "brokered": true,
     "origin": {
       "name": "origin-name",
       "address_line_1": "origin-address-line-1",
@@ -204,6 +204,7 @@ Response:
     "load_id": "load-id", // The load_id you sent us when creating the load
     "external_id": "external-id", // The external_id you sent us when creating the load
     "status": "new",
+    "brokered": true,
     "tms_created_at": "2016-07-15 19:00:00 +0200",
     "tms_updated_at": "2016-07-17 19:00:00 +0200",
     "target_delivery_start": "2016-07-17 19:00:00 +0200",

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -436,6 +436,14 @@ Request:
           "external_id": "load-external-id"
         }
       ],
+      "charges": {
+        "total": 1200.23,
+        "currency": "USD",
+        "line_haul": 1100.32,
+        "fuel": 129.32,
+        "detention": 22.22,
+        "other": 87.87
+      },
       "line_items": [
         {
           "description": "line item description",
@@ -444,13 +452,26 @@ Request:
           "type_code": "abc"
         }
       ],
-      "charges": {
-        "total": 1200.23,
-        "currency": "USD",
-        "line_haul": 1100.32,
-        "fuel": 129.32,
-        "detention": 22.22,
-        "other": 87.87
+      "shipped_items": [ // empty array if no shipped items
+        {
+          "external_id": "1234", // Required
+          "description": "Shipped item", // Required
+          "weight_unit": "lb",
+          "quantity": 2.0,
+          "item_type": "CARTON",
+          "hazardous_material": false,
+          "weight": 417.0,
+          "class_name": '400',
+          "nmfc": "82270",
+          "width": 10.0,
+          "height": 12.0,
+          "length": 20.0
+        }
+      ],
+      "references": { // empty object if no references
+        "Key": "Value",
+        "Key2": "Value2,Value3",
+        "Anything": "You Want"
       }
     }
   ]

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -59,7 +59,7 @@ Request:
     "primary_reference_type": "primary-reference-type",
     "quantity": 1,
     "weight": 1000,
-    "distance": "500",
+    "distance": 500,
     "mode": "truck",
     "freight_class": "class",
     "po": "po",
@@ -136,10 +136,10 @@ Request:
         "external_id": "line_item_1", // You're id for matching up line items when sending back to your TMS
         "description": "line item description",
         "total": 123.45,
+        "customer_total": 150.00,
         "quantity": 5,
         "rate": 2.0,
         "type_code": "abc",
-        "customer_total": 150.00,
         "carrier": { // Used to calculate carrier_charge for each carrier
           "external_id": "carrier-external-id",
           "scac": "scac",
@@ -150,13 +150,13 @@ Request:
     "shipped_items": [{
       "external_id": "1234", // Required
       "description": "Shipped item", // Required
-      "weight_unit": "lb",
-      "quantity": 2.0,
-      "item_type": "CARTON",
-      "hazardous_material": false,
-      "weight": 417.0,
       "class_name": '400',
+      "item_type": "CARTON",
       "nmfc": "82270",
+      "hazardous_material": false,
+      "quantity": 2.0,
+      "weight": 417.0,
+      "weight_unit": "lb",
       "width": 10.0,
       "height": 12.0,
       "length": 20.0
@@ -223,7 +223,7 @@ Response:
     "primary_reference_type": "primary-reference-type",
     "quantity": 1,
     "weight": 1000,
-    "distance": "500",
+    "distance": 500,
     "mode": "truck",
     "freight_class": "class",
     "po": "po",
@@ -300,10 +300,10 @@ Response:
         "external_id": "line_item_1", // You're id for matching up line items when sending back to your TMS
         "description": "line item description",
         "total": 123.45,
+        "customer_total": 150.00,
         "quantity": 5,
         "rate": 2.0,
         "type_code": "abc",
-        "customer_total": 150.00,
         "carrier": { // Used to calculate carrier_charge for each carrier
           "external_id": "carrier-external-id",
           "scac": "scac",
@@ -315,13 +315,13 @@ Response:
       {
         "external_id": "1234", // Required
         "description": "Shipped item", // Required
-        "weight_unit": "lb",
-        "quantity": 2.0,
-        "item_type": "CARTON",
-        "hazardous_material": false,
-        "weight": 417.0,
         "class_name": '400',
+        "item_type": "CARTON",
         "nmfc": "82270",
+        "hazardous_material": false,
+        "quantity": 2.0,
+        "weight": 417.0,
+        "weight_unit": "lb",
         "width": 10.0,
         "height": 12.0,
         "length": 20.0
@@ -464,13 +464,13 @@ Request:
         {
           "external_id": "1234", // Required
           "description": "Shipped item", // Required
-          "weight_unit": "lb",
-          "quantity": 2.0,
-          "item_type": "CARTON",
-          "hazardous_material": false,
-          "weight": 417.0,
           "class_name": '400',
+          "item_type": "CARTON",
           "nmfc": "82270",
+          "hazardous_material": false,
+          "quantity": 2.0,
+          "weight": 417.0,
+          "weight_unit": "lb",
           "width": 10.0,
           "height": 12.0,
           "length": 20.0
@@ -556,13 +556,13 @@ Response:
         {
           "external_id": "1234", // Required
           "description": "Shipped item", // Required
-          "weight_unit": "lb",
-          "quantity": 2.0,
-          "item_type": "CARTON",
-          "hazardous_material": false,
-          "weight": 417.0,
           "class_name": '400',
+          "item_type": "CARTON",
           "nmfc": "82270",
+          "hazardous_material": false,
+          "quantity": 2.0,
+          "weight": 417.0,
+          "weight_unit": "lb",
           "width": 10.0,
           "height": 12.0,
           "length": 20.0
@@ -875,7 +875,7 @@ Response:
       "state": "approved",
       "date": "1981-08-11",
       "date_to_pay": "1981-08-13",
-      "amount_to_pay": "1110.2",
+      "amount_to_pay": 1110.2,
       "quickpay": false,
       "approver": {
         "email": "test@example.com"
@@ -891,10 +891,10 @@ Response:
           "external_id": "line_item_1", // The line external_id you sent us
           "description": "line item description",
           "total": 123.45,
+          "customer_total": 150.00,
           "quantity": 3,
           "rate": 2.0,
           "type_code": "abc",
-          "customer_total": 150.00,
           "carrier": {
             "external_id": "carrier-external-id",
           }
@@ -903,13 +903,13 @@ Response:
       "shipped_items": [{
         "external_id": "1234",
         "description": "Shipped item",
-        "weight_unit": "lb",
-        "quantity": 2.0,
-        "item_type": "CARTON",
-        "hazardous_material": false,
-        "weight": 417.0,
         "class_name": '400',
+        "item_type": "CARTON",
         "nmfc": "82270",
+        "hazardous_material": false,
+        "quantity": 2.0,
+        "weight_unit": "lb",
+        "weight": 417.0,
         "width": 10.0,
         "height": 12.0,
         "length": 20.0

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -18,6 +18,7 @@ All dates + times should be in
 * [Clear Exceptions](#clear-exceptions)
 * [List Approved Invoices](#list-approved-invoices)
 * [Mark Approved Invoice as Received](#mark-approved-invoice-as-received)
+* [Mark Approved Invoice as Not Received](#mark-approved-invoice-as-not-received)
 
 ## Create + Update Loads
 
@@ -956,6 +957,27 @@ POST https://api.hubtran.com/tms/carrier_invoices/:id/received
 
 ```
 curl -X POST https://api.hubtran.com/tms/carrier_invoices/:id/received \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token token=YOUR_TOKEN"
+```
+
+Response:
+
+```
+{
+  "ok": true
+}
+```
+
+## Mark Approved Invoice as Not Received
+
+This is more for when you're developing and you want to reset an invoice
+to mark as received again.
+
+POST https://api.hubtran.com/tms/carrier_invoices/:id/not_received
+
+```
+curl -X POST https://api.hubtran.com/tms/carrier_invoices/:id/not_received \
   -H "Content-Type: application/json" \
   -H "Authorization: Token token=YOUR_TOKEN"
 ```

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -436,6 +436,14 @@ Request:
           "external_id": "load-external-id"
         }
       ],
+      "line_items": [
+        {
+          "description": "line item description",
+          "total": 123.45,
+          "quantity": 5,
+          "type_code": "abc"
+        }
+      ],
       "charges": {
         "total": 1200.23,
         "currency": "USD",

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -452,7 +452,7 @@ Request:
           "type_code": "abc"
         }
       ],
-      "shipped_items": [ // empty array if no shipped items
+      "shipped_items": [
         {
           "external_id": "1234", // Required
           "description": "Shipped item", // Required
@@ -468,7 +468,7 @@ Request:
           "length": 20.0
         }
       ],
-      "references": { // empty object if no references
+      "references": {
         "Key": "Value",
         "Key2": "Value2,Value3",
         "Anything": "You Want"

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -790,6 +790,7 @@ Response:
   "current_page": 1, // current page
   "carrier_invoices": [
     {
+      "id": 123,
       "number": "invoice-number",
       "state": "approved",
       "date": "1981-08-11",
@@ -798,9 +799,12 @@ Response:
       "quickpay": false,
       "approver": {
         "email": "test@example.com"
-      }
+      },
       "carrier": {
         "external_id": "carrier-external-id"
+      },
+      load: {
+        "external_id": "load-external-id"
       },
       "documents": [
         {

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -758,6 +758,7 @@ Request:
 ```
 {
   "document": {
+    "external_id": "document_external_id", // Your id for the document
     "type": "rateConfirmation",
     "url": "URL of image to download. Required unless data is provided",
     "data": "base64 encoded data for image. Required unless url is provided"
@@ -772,7 +773,9 @@ On success:
 {
   "document": {
     "id": 5, // HubTran's internal id for the document
-    "token": "some-random-token" // HubTran's token that can be used in document URLs
+    "token": "some-random-token", // HubTran's token that can be used in document URLs
+    "external_id": "document_external_id", // Your id for the document
+    "type": "rateConfirmation"
   }
 }
 ```

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -14,8 +14,10 @@ All dates + times should be in
 * [Create + Update Carriers](#create--update-carriers)
 * [Bulk Create + Update Carriers](#bulk-create--update-carriers)
 * [Create Payments](#create-payments)
-* [Clear Exceptions](#clear-exceptions)
 * [Document Upload](#document-upload)
+* [Clear Exceptions](#clear-exceptions)
+* [List Approved Invoices](#list-approved-invoices)
+* [Mark Approved Invoice as Received](#mark-approved-invoice-as-received)
 
 ## Create + Update Loads
 
@@ -741,7 +743,6 @@ On Failure:
 
 ## Clear Exceptions
 
-
 POST https://api.hubtran.com/tms/carrier_invoices/:id/exceptions/clear
 
 ```
@@ -755,6 +756,89 @@ Request:
 
 ```
 {}
+```
+
+Response:
+
+```
+{
+  "ok": true
+}
+```
+
+## List Approved Invoices
+
+GET https://api.hubtran.com/tms/carrier_invoices/approved
+
+```
+curl -X GET https://api.hubtran.com/tms/carrier_invoices/approved \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token token=YOUR_TOKEN"
+```
+
+Response:
+
+```
+{
+  "carrier_invoices": [
+    {
+      "number": "invoice-number",
+      "state": "approved",
+      "date": "1981-08-11",
+      "date_to_pay": "1981-08-13",
+      "amount_to_pay": "1110.2",
+      "quickpay": false,
+      "approver": {
+        "email": "test@example.com"
+      }
+      "carrier": {
+        "external_id": "carrier-external-id"
+      },
+      "documents": [
+        {
+          "id": 14,
+          "type": "proofOfDelivery",
+          "proof_of_delivery": true,
+          "url": "https://api.hubtran.com/downloads/documents/unique-id",
+          "visibility": {
+            "carrier": true,
+            "customer": true
+          }
+        }
+      ],
+      "combined_document_urls": [ // All documents of the same type, combined
+        {
+          "type": "proofOfDelivery",
+          "url": "https://api.hubtran.com/downloads/documents/combined/unique-id",
+          "proof_of_delivery": true,
+          "visibility": {
+            "carrier": true,
+            "customer": true
+          }
+        }
+      ],
+      "remit_to": {
+        "name": "name",
+        "address_line_1": "address1",
+        "address_line_2": "address2",
+        "city": "city",
+        "state": "state",
+        "postal_code": "12345",
+        "country": "USA"
+      }
+    }
+  ]
+}
+```
+
+## Mark Approved Invoice as Received
+
+POST https://api.hubtran.com/tms/carrier_invoices/:id/received
+
+```
+curl -X POST https://api.hubtran.com/tms/carrier_invoices/:id/received \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token token=YOUR_TOKEN"
 ```
 
 Response:

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -68,6 +68,7 @@ Request:
     "ppe": "ppe",
     "quote_number": "quote-number",
     "ship_ref": "ship-ref",
+    "brokered": true,
     "origin": {
       "name": "origin-name",
       "address_line_1": "origin-address-line-1",
@@ -134,6 +135,8 @@ Request:
         "description": "line item description",
         "total": 123.45,
         "quantity": 5,
+        "type_code": "abc",
+        "customer_total": 150.00,
         "carrier": { // Used to calculate carrier_charge for each carrier
           "external_id": "carrier-external-id",
           "scac": "scac",
@@ -293,6 +296,8 @@ Response:
         "description": "line item description",
         "total": 123.45,
         "quantity": 5,
+        "type_code": "abc",
+        "customer_total": 150.00,
         "carrier": { // Used to calculate carrier_charge for each carrier
           "external_id": "carrier-external-id",
           "scac": "scac",
@@ -815,6 +820,9 @@ Response:
         {
           "description": "line item description",
           "total": 123.45,
+          "quantity": 3,
+          "type_code": "abc",
+          "customer_total": 150.00,
           "carrier": {
             "external_id": "carrier-external-id",
           }

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -539,6 +539,37 @@ Response:
         "fuel": 129.32,
         "detention": 22.22,
         "other": 87.87
+      },
+      "line_items": [
+        {
+          "external_id": "line_item_1", // The line external_id you sent us
+          "description": "line item description",
+          "total": 123.45,
+          "quantity": 5,
+          "rate": 2.0,
+          "type_code": "abc"
+        }
+      ],
+      "shipped_items": [
+        {
+          "external_id": "1234", // Required
+          "description": "Shipped item", // Required
+          "weight_unit": "lb",
+          "quantity": 2.0,
+          "item_type": "CARTON",
+          "hazardous_material": false,
+          "weight": 417.0,
+          "class_name": '400',
+          "nmfc": "82270",
+          "width": 10.0,
+          "height": 12.0,
+          "length": 20.0
+        }
+      ],
+      "references": {
+        "Key": "Value",
+        "Key2": "Value2,Value3",
+        "Anything": "You Want"
       }
     }
   ]

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -776,10 +776,18 @@ curl -X GET https://api.hubtran.com/tms/carrier_invoices/approved \
   -H "Authorization: Token token=YOUR_TOKEN"
 ```
 
+Optional URL params:
+
+1. `results_per_page` - number of results to return per page, max 50
+2. `page` - which page of results to return based on `results_per_page`
+
 Response:
 
 ```
 {
+  "results_per_page": 20, // how many results per page
+  "page_count": 2, // number of pages using results_per_page
+  "current_page": 1, // current page
   "carrier_invoices": [
     {
       "number": "invoice-number",

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -733,6 +733,7 @@ On success:
 {
   "document": {
     "id": 5, // HubTran's internal id for the document
+    "token": "some-random-token" // HubTran's token that can be used in document URLs
   }
 }
 ```

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -741,10 +741,10 @@ Please let us know if you would like to use this API, as it needs to be enabled 
 POST https://api.hubtran.com/tms/documents
 
 ```
-curl -X POST https://api.hubtran.com/tms/documents \
+curl -X POST https://api.hubtran.com/tms/loads/:external_id/documents \
   -H "Content-Type: application/json" \
   -H "Authorization: Token token=YOUR_TOKEN" \
-  -d '{"document":{"load_id": "1234","type":"invoice","url":"url of image"}}'
+  -d '{"document":{"type":"invoice","url":"url of image"}}'
 ```
 
 Request:
@@ -752,7 +752,6 @@ Request:
 ```
 {
   "document": {
-    "load_id": "2134",
     "type": "rateConfirmation",
     "url": "URL of image to download. Required unless data is provided",
     "data": "base64 encoded data for image. Required unless url is provided"

--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -38,10 +38,13 @@ choose which payloads you want to use and ignore the rest.
       },
       "line_items": [ // Only present if line items is enabled for the account
         {
+          "external_id": "line-item-external-id",
           "description": "line item description",
           "total": 123.45,
           "quantity": 5,
+          "rate": 2.0,
           "type_code": "Line Haul",
+          "customer_total": 150.00,
           "carrier": {
             "external_id": "carrier-external-id",
           }

--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -30,7 +30,7 @@ choose which payloads you want to use and ignore the rest.
       "number": "invoice-number",
       "date": null,
       "date_to_pay": "1981-08-13",
-      "amount_to_pay": "10.2",
+      "amount_to_pay": 10.2,
       "quickpay": false,
       "payment_strategy": "direct", // or "factor"
       "approver": {
@@ -41,10 +41,10 @@ choose which payloads you want to use and ignore the rest.
           "external_id": "line-item-external-id",
           "description": "line item description",
           "total": 123.45,
+          "customer_total": 150.00,
           "quantity": 5,
           "rate": 2.0,
           "type_code": "Line Haul",
-          "customer_total": 150.00,
           "carrier": {
             "external_id": "carrier-external-id",
           }


### PR DESCRIPTION
* List approved invoices
* Mark an invoice as received

I can't remember if they required something that listed ids, a show action, and a mark as received. This just lists the full invoice using the JSON from the "show" load response. 