### PR TITLE
Fix verifications example to use numeric string

### DIFF
--- a/factors/rest.md
+++ b/factors/rest.md
@@ -178,7 +178,7 @@ Response:
   "state": "success",            // Required
   "disclosure_details": {        // Optional, may be `null`
     "amount_mismatch_failure": {
-      "broker_amount": 50.0      // Optional additional data
+      "broker_amount": "50.0"    // Optional additional data
     }
   }
 }


### PR DESCRIPTION
Verified that this is how we store/send it. Also, later in the document, this field is specified as a numeric string, so I probably forgot to update this example.