### PR TITLE
Fix date and remove date_to_pay

### DIFF
--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -28,8 +28,7 @@ choose which payloads you want to use and ignore the rest.
     "id": 7,                            // HubTran's internal id
     "invoice": {
       "number": "invoice-number",
-      "date": null,
-      "date_to_pay": "1981-08-13",
+      "date": "2019-08-13",
       "amount_to_pay": 10.2,
       "currency": "USD",
       "quickpay": false,


### PR DESCRIPTION
`date` is the important one and our documentation was showing null. Removing date_to_pay since I believe we removed this from the UI and we don't want to confuse people. 