### PR TITLE
Add suggestion to retry requests

### DIFF
--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -7,6 +7,8 @@ HubTran to work well, we need as much information as you can give us.
 All dates + times should be in
 [iso8601](https://en.wikipedia.org/wiki/ISO_8601) format. All `external_id`s should be strings.
 
+If you receive a status code other than 2xx, please retry your request once with a slight delay - there may be a temporary issue such as resource locking that resolves itself upon retry.
+
 * [Authentication](../rest_authentication.md)
 * [Create + Update Loads](#create--update-loads)
 * [Load Details](#load-details)

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -7,7 +7,7 @@ HubTran to work well, we need as much information as you can give us.
 All dates + times should be in
 [iso8601](https://en.wikipedia.org/wiki/ISO_8601) format. All `external_id`s should be strings.
 
-If you receive a status code other than 2xx, please retry your request once with a slight delay - there may be a temporary issue such as resource locking that resolves itself upon retry.
+If you receive a status code other than 2xx, please retry your request once with a slight delay - there may be a temporary issue that resolves itself upon retry.
 
 * [Authentication](../rest_authentication.md)
 * [Create + Update Loads](#create--update-loads)


### PR DESCRIPTION
Add suggestion to retry requests if the status code is something other than 2xx. The motivating case here was that sometimes we get postgres-level locking that prevents a TMS update from going through. In this case, we return a 422 or 423 status code.