### PR TITLE
Add in shipment approval information

### DIFF
--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -46,7 +46,21 @@ choose which payloads you want to use and ignore the rest.
       "note": "Put load id on check.",
       "load": {
         "external_id": "load-external-id", // YOUR internal id
-        "shipments": [],
+        "shipments": [
+          {
+            "status": "approved",
+            "details": {
+              "date": "2020-01-22T00:00:00.000Z",
+              "number": "invoice-number"
+            }
+          },
+          {
+            "status": "rejected",
+            "details": {
+              "reason": "Missing BOL"
+            }
+          }
+        ],
         "customer": {
           "external_id": "carrier-external-id"
         }
@@ -163,7 +177,24 @@ choose which payloads you want to use and ignore the rest.
           "subject": "subject of email 2",
           "received_at": "2020-03-06T00:00:00.000Z"
         }
-      ]
+      ],
+      "load": {
+        "shipments": [ 
+          {
+            "status": "approved",
+            "details": {
+              "date": "2020-01-22T00:00:00.000Z",
+              "number": "invoice-number"
+            }
+          },
+          {
+            "status": "rejected",
+            "details": {
+              "reason": "Missing BOL"
+            }
+          }
+        ]
+      }
     },
     "exceptions": [
       {

--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -50,7 +50,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "status": "approved",
             "details": {
-              "date": "2020-01-22T00:00:00.000Z",
+              "date": "2020-01-22",
               "number": "invoice-number"
             }
           },
@@ -183,7 +183,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "status": "approved",
             "details": {
-              "date": "2020-01-22T00:00:00.000Z",
+              "date": "2020-01-22",
               "number": "invoice-number"
             }
           },


### PR DESCRIPTION
Document extra shipment approval information.

Approved shipments will have `date` and `number`.

Rejected shipments will have a `reason`.

If account doesn't support shipment approval information, the shipments list will be empty.