### PR TITLE
Add in shipment approval information

### DIFF
--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -50,6 +50,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "status": "approved",
             "details": {
+              "id": "shipment-1",
               "date": "2020-01-22",
               "number": "invoice-number"
             }
@@ -57,6 +58,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "status": "rejected",
             "details": {
+              "id": "shipment-2",
               "reason": "Missing BOL"
             }
           }
@@ -179,10 +181,11 @@ choose which payloads you want to use and ignore the rest.
         }
       ],
       "load": {
-        "shipments": [ 
+        "shipments": [
           {
             "status": "approved",
             "details": {
+              "id": "shipment-1",
               "date": "2020-01-22",
               "number": "invoice-number"
             }
@@ -190,6 +193,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "status": "rejected",
             "details": {
+              "id": "shipment-2",
               "reason": "Missing BOL"
             }
           }

--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -50,7 +50,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "status": "approved",
             "details": {
-              "id": "shipment-1",
+              "external_id": "shipment-1",
               "date": "2020-01-22",
               "number": "invoice-number"
             }
@@ -58,7 +58,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "status": "rejected",
             "details": {
-              "id": "shipment-2",
+              "external_id": "shipment-2",
               "reason": "Missing BOL"
             }
           }
@@ -185,7 +185,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "status": "approved",
             "details": {
-              "id": "shipment-1",
+              "external_id": "shipment-1",
               "date": "2020-01-22",
               "number": "invoice-number"
             }
@@ -193,7 +193,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "status": "rejected",
             "details": {
-              "id": "shipment-2",
+              "external_id": "shipment-2",
               "reason": "Missing BOL"
             }
           }

--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -48,17 +48,17 @@ choose which payloads you want to use and ignore the rest.
         "external_id": "load-external-id", // YOUR internal id
         "shipments": [
           {
+            "external_id": "shipment-1",
             "status": "approved",
             "details": {
-              "external_id": "shipment-1",
               "date": "2020-01-22",
               "number": "invoice-number"
             }
           },
           {
+            "external_id": "shipment-2",
             "status": "rejected",
             "details": {
-              "external_id": "shipment-2",
               "reason": "Missing BOL"
             }
           }
@@ -183,17 +183,17 @@ choose which payloads you want to use and ignore the rest.
       "load": {
         "shipments": [
           {
+            "external_id": "shipment-1",
             "status": "approved",
             "details": {
-              "external_id": "shipment-1",
               "date": "2020-01-22",
               "number": "invoice-number"
             }
           },
           {
+            "external_id": "shipment-2",
             "status": "rejected",
             "details": {
-              "external_id": "shipment-2",
               "reason": "Missing BOL"
             }
           }

--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -50,7 +50,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "external_id": "shipment-1",
             "status": "approved",
-            "details": {
+            "status_details": {
               "date": "2020-01-22",
               "number": "invoice-number"
             }
@@ -58,7 +58,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "external_id": "shipment-2",
             "status": "rejected",
-            "details": {
+            "status_details": {
               "reason": "Missing BOL"
             }
           }
@@ -185,7 +185,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "external_id": "shipment-1",
             "status": "approved",
-            "details": {
+            "status_details": {
               "date": "2020-01-22",
               "number": "invoice-number"
             }
@@ -193,7 +193,7 @@ choose which payloads you want to use and ignore the rest.
           {
             "external_id": "shipment-2",
             "status": "rejected",
-            "details": {
+            "status_details": {
               "reason": "Missing BOL"
             }
           }

--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -46,7 +46,21 @@ choose which payloads you want to use and ignore the rest.
       "note": "Put load id on check.",
       "load": {
         "external_id": "load-external-id", // YOUR internal id
-        "shipments": [],
+        "shipments": [
+          {
+            "status": "approved",
+            "details": {
+              "date": "2020-01-22",
+              "number": "invoice-number"
+            }
+          },
+          {
+            "status": "rejected",
+            "details": {
+              "reason": "Missing BOL"
+            }
+          }
+        ],
         "customer": {
           "external_id": "carrier-external-id"
         }
@@ -163,7 +177,24 @@ choose which payloads you want to use and ignore the rest.
           "subject": "subject of email 2",
           "received_at": "2020-03-06T00:00:00.000Z"
         }
-      ]
+      ],
+      "load": {
+        "shipments": [ 
+          {
+            "status": "approved",
+            "details": {
+              "date": "2020-01-22",
+              "number": "invoice-number"
+            }
+          },
+          {
+            "status": "rejected",
+            "details": {
+              "reason": "Missing BOL"
+            }
+          }
+        ]
+      }
     },
     "exceptions": [
       {

--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -61,6 +61,11 @@ choose which payloads you want to use and ignore the rest.
             "status_details": {
               "reason": "Missing BOL"
             }
+          },
+          {
+            "external_id": "shipment-3",
+            "status": "pending",
+            "status_details": {}
           }
         ],
         "customer": {
@@ -196,6 +201,11 @@ choose which payloads you want to use and ignore the rest.
             "status_details": {
               "reason": "Missing BOL"
             }
+          },
+          {
+            "external_id": "shipment-3",
+            "status": "pending",
+            "status_details": {}
           }
         ]
       }


### PR DESCRIPTION
Document extra shipment approval information.

Approved shipments will have date and number.

Rejected shipments will have a reason.

If account doesn't support shipment approval information, the shipments list will be empty.