### PR TITLE
Add field for plain text rules.

### DIFF
--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -775,6 +775,10 @@ Request:
     "external_id": "customer-external-id",                      // Required
     "name": "customer-name",                                    // Required
     "account_number": "customer-account-number",                // Required
+    "carrier_invoice_reminders": [                              // Optional
+      "Confirm with Sandy before approving.",
+      "Check this other thing before approving."
+    ],
     "invoicing": {
       "bill_to": {
         "name": "name",
@@ -834,6 +838,10 @@ Response:
     "external_id": "customer-external-id",  // YOUR internal id for the customer
     "name": "customer-name",
     "account_number": "customer-account-number",
+    "carrier_invoice_reminders": [
+      "Confirm with Sandy before approving.",
+      "Check this other thing before approving."
+    ],
     "invoicing": {
       "bill_to": {
         "name": "name",


### PR DESCRIPTION
`carrier_invoice_reminders` felt a little more descriptive as a client-facing field name than `custom_plain_text_rules`. Adding terminology has the downside of creating more confusion for _us_ when talking about the feature, but in this case it feels like the right thing to do for the customer. Open to other names too.