### PR TITLE
Add shipment_id to the loads and shipments APIs

### DIFF
--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -46,8 +46,8 @@ Request:
 ```
 {
   "load": {
-    "load_id": "load-id",                                 // Required
-    "external_id": "external-id",                         // Required
+    "load_id": "load-id",                                 // Required, human-friendly, but for backwards compatibility, will default to external_id
+    "external_id": "external-id",                         // Required, machine-friendly
     "status": "new",                                      // Recommended
     "brokered": true,
     "tms_created_at": "2016-07-15 19:00:00 +0200",
@@ -112,7 +112,9 @@ Request:
       "account_number": "customer-account-number"
     },
     "shipments": [                                        // Used to link the load to shipments created via the shipment API
+      // Shipments will be created if they don't exist
       {
+        "shipment_id": "shipment-id",
         "external_id": "shipment-external-id"
       }
     ],
@@ -446,7 +448,8 @@ Request:
 {
   "shipments": [
     {
-      "external_id": "shipment-external-id",              // Required
+      "shipment_id": "shipment-id",                       // Required, human-friendly, but for backwards compatibility, will default to external_id
+      "external_id": "external-id",                       // Required, machine-friendly
       "status": "new",                                    // Recommended
       "tms_created_at": "2016-07-10 20:43:00 +0300",
       "tms_updated_at": "2016-07-15 20:43:00 +0300",
@@ -484,7 +487,9 @@ Request:
         "account_number": "customer-account-number"
       },
       "loads": [                                          // Used to link shipments and loads representing a "delivery"
+        // Loads will be created if they don't already exist
         {
+          "load_id": "load-id",
           "external_id": "load-external-id"
         }
       ],


### PR DESCRIPTION
Right now shipment external_id is used for both the machine-readable identifier and the human-readable identifier. This splits them into shipment_id and external_id similar to loads.

We're adding shipment_id and load_id to the areas that link them back and forth so we can create the shipment or loads with the right identifiers.