### PR TITLE
Update csv.md

### DIFF
--- a/brokers/csv.md
+++ b/brokers/csv.md
@@ -47,7 +47,7 @@ Required fields are **bold**.
 * days_to_pay
 * quickpay - true or false, default is false
 * payment_strategy - direct or triumphpay, defaults to direct
-* **remit_to_name**
+* remit_to_name
 * remit_to_address_line_1 - recommended
 * remit_to_address_line_2 - recommended
 * remit_to_city - recommended


### PR DESCRIPTION
We show that we require remit_to_name in documentation, but don't actually require it and default to the name if not passed.
Do we just pretend it's required as it's nice to have, or should we remove it.