### PR TITLE
Update comment on labels key in the carrier endpoint

### DIFF
--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -648,7 +648,7 @@ Request:
     "priority": "Tier 1",
     "days_to_pay": 10,                    // Recommended
     "payment_strategy": "direct",         // direct or triumphpay, defaults to direct
-    "labels": ["LABEL1","LABEL2"],        // Omit this key unless you want to overwrite user-selected labels
+    "labels": ["LABEL1","LABEL2"],        // Omit this key unless you want to overwrite existing labels set through the API
     "contacts": [                         // Recommended
       "joe@example.com",
       "tom@example.com"


### PR DESCRIPTION
If labels are passed through the API, they now only overwrite other
labels that were passed through the API. They won't overwrite labels set
within HubTran.

See: https://github.com/HubTran/hubtran-web/commit/1c25e1d9e3cbf67f8a532a95fcbe72c7ed90076e