### PR TITLE
Add documents only endpoint documentation

### DIFF
--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -1364,8 +1364,7 @@ HTTP Status Code 422
 
 ## Create Documents Only Carrier Invoice Submissions
 
-This endpoint allows documents to be sent via the endpoint for future processing. This will create an item in the "New" queue just like if HubTran received an email with paperwork.
-
+This endpoint allows documents to be sent via the endpoint for future processing. This will create an item in the "New" queue just like if TriumphPay received an email with paperwork.
 
 POST https://api.hubtran.com/broker/invoice_submission_documents
 

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -22,6 +22,7 @@ If you receive a status code other than 2xx, please retry your request once with
 * [Mark Approved Invoice as Verified](#mark-approved-invoice-as-verified)
 * [Mark Approved Invoice as Not Verified](#mark-approved-invoice-as-not-verified)
 * [Create Carrier Invoice Submissions](#create-carrier-invoice-submissions)
+* [Create Documents Only Carrier Invoice Submissions](#create-carrier-invoice-submissions-documents-only)
 * [List Transmissions](#list-transmissions)
 * [Mark Transmission as Verified](#mark-transmission-as-verified)
 * [Update Account](#update-account)
@@ -1327,7 +1328,7 @@ Request:
         "external_id": "d123",      // Optional, your internal ID for the document.
         "file_name": "invoice.pdf", // Required
         "data": DATA                // Required, base64-encoded document data
-        "doctype": "BOL".           // Optional doctype for the document
+        "document_type": "BOL".     // Optional document_type for the document, see Document Type endpoint for valid values.
         "POD": false,               // Optional flag if document is POD, boolean
       },
       {
@@ -1359,6 +1360,73 @@ HTTP Status Code 422
   "errors": [
     {
       "message": "carrier is missing" // Error message describing the issue.
+    }
+  ]
+}
+```
+
+## Create Documents Only Carrier Invoice Submissions
+
+This endpoint allows documents to be sent via the endpoint for future processing. This will create an item in the "New" queue just like if HubTran received an email with paperwork.
+
+
+POST https://api.hubtran.com/broker/invoice_submission_documents
+
+```
+curl -X POST https://api.hubtran.com/broker/invoice_submission_documents \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Token token=YOUR_TOKEN" \
+  -d '{...}'
+```
+
+%% Request:
+
+```
+{
+  "external_id": "123123",
+  "documents": [
+     {
+        "external_id": "123",
+        "document_type": "invoice". // Optional document_type for the document, see Document Type endpoint for valid values.
+        "POD": false,
+        "file_name": "foo.txt",
+        "data": DATA                // base64-encoded document data
+      },
+      {
+        "external_id": "456",
+        "document_type": "invoice".  // Optional document_type for the document, see Document Type endpoint for valid values.
+        "POD": true,
+        "file_name": "bar.txt",
+        "data": DATA                // base64-encoded document data
+      }
+   ],
+   "vendor": {
+     "external_id": "a_valid_external_id", // Required
+     "sender_email": "valid_email@example.com"
+    },
+     "load_id": "valid_load_id", // Required
+ }
+ ```
+
+Success Response:
+
+```
+HTTP Status Code 201
+{
+  "invoice": {
+    "id": 123 // The HubTran ID of the invoice if you want to store it
+  }
+}
+```
+
+Failure Response:
+
+```
+HTTP Status Code 422
+{
+  "errors": [
+    {
+      "message": "load_id is missing" // Error message describing the issue.
     }
   ]
 }

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -1287,9 +1287,6 @@ If you already have an invoice submission from a carrier (paperwork and/or invoi
 you may want to programatically flow that into TriumphPay Audit. This will create an item in the "New" queue
 just like if TriumphPay Audit received an email with paperwork.
 
-If only an `externai_id` is submitted, `documents` are required, and it's assumed that these are being submitted for
-future processing, and all other invoice fields are ignored.
-
 For invoices submitted via this API, TriumphPay Audit will not perform machine learning and data extraction
 on the submitted documents. Instead we will use the invoice data you submit, as the sole source of data
 about the invoice.
@@ -1309,10 +1306,10 @@ Request:
 {
   "invoice": {
     "external_id": "456",    // Required, your internal ID
-    "source": "web_billing", // Required if not only documents
-    "number": "111",         // Required if not only documents
-    "amount": 123.0,         // Required if not only documents
-    "date": "2019-04-09",    // Required if not only documents, in iso8601 format
+    "source": "web_billing", // Required, valid sources are "web_billing", "triumphpay"
+    "number": "111",         // Required
+    "amount": 123.0,         // Required
+    "date": "2019-04-09",    // Required, in iso8601 format
     "quickpay": true,
     "other": {
       "trailer": "333",  // Optional

--- a/brokers/rest.md
+++ b/brokers/rest.md
@@ -1384,22 +1384,22 @@ curl -X POST https://api.hubtran.com/broker/invoice_submission_documents \
   "documents": [
      {
         "external_id": "123",
-        "document_type": "invoice". // Optional document_type for the document, see Document Type endpoint for valid values.
-        "POD": false,
+        "document_type": "invoice", // Optional document_type for the document, see Document Type endpoint for valid values.
+        "POD": false,               // Optional flag if document is POD, boolean
         "file_name": "foo.txt",
         "data": DATA                // base64-encoded document data
       },
       {
         "external_id": "456",
-        "document_type": "invoice".  // Optional document_type for the document, see Document Type endpoint for valid values.
-        "POD": true,
+        "document_type": "invoice",  // Optional document_type for the document, see Document Type endpoint for valid values.
+        "POD": true,                 // Optional flag if document is POD, boolean
         "file_name": "bar.txt",
-        "data": DATA                // base64-encoded document data
+        "data": DATA                 // base64-encoded document data
       }
    ],
    "vendor": {
-     "external_id": "a_valid_external_id", // Required
-     "sender_email": "valid_email@example.com"
+     "external_id": "a_valid_external_id", // Required, the vendor or carrier id that matches id in TMS.
+     "sender_email": "carrier@example.com" // Optional, email address of carrier who originally submitted paperwork.
     },
      "load_id": "valid_load_id", // Required
  }


### PR DESCRIPTION
This PR adds documentation for our new documents only carrier invoice submission endpoint that allows for documents to be sent via the API to the "New" queue.