### PR TITLE
Adding scraped_carrier_invoice_data to payload

### DIFF
--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -261,7 +261,8 @@ choose which payloads you want to use and ignore the rest.
         ],
         "load": {"external_id": "external-id"},
         "carrier": {"external_id": "external-id"}, // If there is no carrier, it'll come through as null
-        "shipments": [{"external_id": "external-id"}]
+        "shipments": [{"external_id": "external-id"}],
+        "scraped_carrier_invoice_data": [{"invoice_amount": "invoice-amount"}]
       }
     ]
   }

--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -262,10 +262,12 @@ choose which payloads you want to use and ignore the rest.
         "load": {"external_id": "external-id"},
         "carrier": {"external_id": "external-id"}, // If there is no carrier, it'll come through as null
         "shipments": [{"external_id": "external-id"}],
-        "scraped_carrier_invoice_data": {
-          "total_charge_amount": "100",
-          "total_charge_currency: "USD"
-         }
+        "scraped_carrier_invoice": {
+          "total_amount": {
+            "amount": "100",
+            "currency": "USD"
+          }
+        }
       }
     ]
   }

--- a/brokers/webhook.md
+++ b/brokers/webhook.md
@@ -262,7 +262,10 @@ choose which payloads you want to use and ignore the rest.
         "load": {"external_id": "external-id"},
         "carrier": {"external_id": "external-id"}, // If there is no carrier, it'll come through as null
         "shipments": [{"external_id": "external-id"}],
-        "scraped_carrier_invoice_data": [{"invoice_amount": "invoice-amount"}]
+        "scraped_carrier_invoice_data": {
+          "total_charge_amount": "100",
+          "total_charge_currency: "USD"
+         }
       }
     ]
   }


### PR DESCRIPTION
To pass along the scraped invoice_amount data, we'll add it here as an additional collection on the `Load Documents Attached` payload.

Does everyone feel this is the correct place for this, and does anyone have any ideas on the naming of this schema extension?